### PR TITLE
Fix pnpm workspaces bug

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,7 +9,7 @@ export default {
       const out = transformSync(src, {
         plugins: [
           [
-            'relay',
+            require.resolve('babel-plugin-relay'),
             {
               eagerESModules: true,
             },


### PR DESCRIPTION
With more strict packages installers like `pnpm`, we cannot guarantee that the `babel-plugin-relay` package can be resolved by the `@babel/core` package. To work solve this, we can resolve the path in this module using `require.resolve`, which will avoid the resolution of the package happening in the babel module.

I verified that this fixes a bug where this package does not work with pnpm workspaces.