### PR TITLE
Use dev server when running tests

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -7,6 +7,9 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      let global = globalThis;
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/example/package.json
+++ b/example/package.json
@@ -6,8 +6,9 @@
     "dev": "concurrently \"npm:dev:*\"",
     "dev:vite": "vite",
     "dev:relay": "relay-compiler --watch",
+    "preview": "relay-compiler && vite preview --port 3000",
     "build": "relay-compiler && tsc --noEmit && vite build",
-    "test": "concurrently \"npm:build\" && playwright test"
+    "test": "playwright test"
   },
   "dependencies": {
     "react": "^17.0.0",

--- a/example/playwright.config.ts
+++ b/example/playwright.config.ts
@@ -1,0 +1,9 @@
+import { PlaywrightTestConfig } from "@playwright/test";
+
+const config: PlaywrightTestConfig = {
+  webServer: {
+    command: "yarn dev",
+    port: 3000,
+  },
+};
+export default config;

--- a/example/src/App.spec.ts
+++ b/example/src/App.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, Page } from "@playwright/test";
 import { GraphQLResponseWithData as RelayGraphQLResponseWithData } from "relay-runtime";
-import path from "path";
 import { AppQueryResponse } from "./__generated__/AppQuery.graphql";
 
 // Mutable removes the readonly property from a type. This is done because the Relay compiler outputs types with readonly fields.
@@ -28,25 +27,7 @@ async function modifyGraphQLResponse(
   });
 }
 
-// This beforeEach hook ensures that the compiled Vite project is served at http://localhost/ for each test.
-test.beforeEach(async ({ page }) => {
-  await page.route("http://localhost/**", (route) => {
-    if (route.request().resourceType() === "document") {
-      return route.fulfill({
-        status: 200,
-        path: path.join(__dirname, "../dist/index.html"),
-      });
-    } else {
-      const url = new URL(route.request().url());
-      return route.fulfill({
-        status: 200,
-        path: path.join(__dirname, "../dist", url.pathname),
-      });
-    }
-  });
-});
-
-test("renders list with many ships", async ({ page }) => {
+test("renders list with many ships", async ({ page, baseURL }) => {
   await modifyGraphQLResponse(
     page,
     "https://api.spacex.land/graphql",
@@ -66,7 +47,7 @@ test("renders list with many ships", async ({ page }) => {
     },
   );
 
-  await page.goto(`http://localhost`, { waitUntil: "networkidle" });
+  await page.goto(baseURL || "/", { waitUntil: "networkidle" });
 
   // Check title exists and hence that page rendered correctly
   const titleTxt = page.locator("h1");
@@ -82,7 +63,7 @@ test("renders list with many ships", async ({ page }) => {
   await expect(await shipsListChildren.nth(1).textContent()).toBe("Ship Two");
 });
 
-test("renders list with no ships", async ({ page }) => {
+test("renders list with no ships", async ({ page, baseURL }) => {
   await modifyGraphQLResponse(
     page,
     "https://api.spacex.land/graphql",
@@ -92,7 +73,7 @@ test("renders list with no ships", async ({ page }) => {
     },
   );
 
-  await page.goto(`http://localhost`, { waitUntil: "networkidle" });
+  await page.goto(baseURL || "/", { waitUntil: "networkidle" });
 
   // Check title exists and hence that page rendered correctly
   const titleTxt = page.locator("h1");


### PR DESCRIPTION
Configured the playwright web server to boot the vite dev server.
This way the requests are automatically handled and doesn't have to be configures in the test files themselves.