### PR TITLE
Pass filename to babel-plugin-relay

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -16,6 +16,7 @@ export default {
           ],
         ],
         code: true,
+        filename: id,
       });
 
       if (!out?.code) throw new Error("vite-plugin-react Failed to build");


### PR DESCRIPTION
Internally `babel-plugin-relay` uses the filename to find the right relative import paths when an `artifactDirectory` is configured. Currently `vite-plugin-relay` executes the plugin against a source string (rather than a file) this isn't present and the plugin fails. This just updates the babel invocation to propagate the filename.