### PR TITLE
Use type: module for Vite 3 example

### DIFF
--- a/examples/vite-3/package.json
+++ b/examples/vite-3/package.json
@@ -2,6 +2,7 @@
   "name": "example-vite-3",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "scripts": {
     "dev": "concurrently \"npm:dev:*\"",
     "dev:vite": "vite",


### PR DESCRIPTION
New Vite projects use `"type": "module"` per default. Supporting this in parallel to Vite 2 was one of the efforts of my original PR for Vite 3 support. Re-adding the `"type": "module"` to test this case.