### PR TITLE
Create sourcemaps for the relay plugin transformation

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,25 +4,26 @@ import { transformSync } from "@babel/core";
 export default {
   name: "vite:relay",
   transform(src, id) {
-    let code = src;
 
     if (/.(t|j)sx?/.test(id) && src.includes("graphql`")) {
       const out = transformSync(src, {
         plugins: [["babel-plugin-relay"]],
         code: true,
         filename: id,
+        sourceMaps: true,
       });
 
       if (!out?.code) {
         throw new Error(`vite-plugin-relay: Failed to transform ${id}`);
       }
 
-      code = out.code;
-    }
+      const code = out.code;
+      const map = out.map;
 
-    return {
-      code,
-      map: null,
-    };
+      return {
+        code,
+        map,
+      };
+    }
   },
 } as PluginOption;


### PR DESCRIPTION
This PR fixes broken sourcemaps when using this plugin. The issue is, that the transfomations made by the `babel-plugin-relay` transformation will not be tracked by vite if we return `null` for the source maps. Vite therefore treats the transformations made by this plugin as a noop from a sourcemap perspective. Since the plugin introduces several whitespaces, sourcemaps are practically unusable.